### PR TITLE
Quick and dirty way to set up local db service with docker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@ NEXTAUTH_URL=http://localhost:3000
 AUTH_SECRET=a-random-string
 JWT_SECRET=a-random-string
 
-DATABASE_URL=
+DATABASE_URL=postgres://root:password@localhost:5432/nextapp
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 GITHUB_CLIENT_ID=

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ yarn-error.log*
 .env.development.local
 .env.test.local
 .env.production.local
+
+# ignore workspace settings
+.vscode
+.idea

--- a/README.md
+++ b/README.md
@@ -17,24 +17,31 @@ The entire boilerplate is written in [Typescript](https://www.typescriptlang.org
 <br />
 
 ## From cloning to deploying, a step by step guide
+
 Follow along to get your own version of this boilerplate deployed on Vercel.
 
 <br />
 
 #### Fork and clone repository
+
 [Fork the repository](https://guides.github.com/activities/forking/) into your own account then clone the fork to your local development environment.
+
 ```
 git clone git@github.com:[USERNAME]/next-fullstack.git
 ```
+
 <br />
 
 #### Install dependencies
+
 ```
 yarn install
 ```
+
 <br />
 
 #### Set up local environment variable
+
 The environment variables required by this boilerplate can be seen in `.env.example`. Create a local environment variable file:
 
 ```
@@ -46,17 +53,21 @@ We'll be setting up a database and also OAuth providers in upcoming steps to get
 <br />
 
 #### Create a Postgres database
+
 You can create a Postgres database with any service provider. Make sure it is publicly accessible and is password authenticated.
 
 👉 [See example settings for creating an AWS RDS Postgres database.](docs/aws-rds-example.png)
 
 After creation, compose the database URL and update your local environment variable file (`.env.local`)
+
 ```
 DATABASE_URL=postgres://[USERNAME]:[PASSWORD]@[HOST]:[PORT]/postgres
 ```
+
 <br />
 
 #### Run migrations
+
 Create tables `users` and `posts`.
 
 ```
@@ -68,14 +79,14 @@ These are example models and tables. Feel free to roll back (`yarn sequelize-cli
 <br />
 
 #### Set up OAuth providers
-The boilerplate comes set up with Github and Google as OAuth providers, however you are free to [remove or add your own](https://next-auth.js.org/providers/github) by editing the provider entries in the [`[next-auth].ts` file](https://github.com/belay-labs/next-fullstack/blob/master/pages/api/auth/%5B...nextauth%5D.ts#L11) and adding the relevant environment variables. 
+
+The boilerplate comes set up with Github and Google as OAuth providers, however you are free to [remove or add your own](https://next-auth.js.org/providers/github) by editing the provider entries in the [`[next-auth].ts` file](https://github.com/belay-labs/next-fullstack/blob/master/pages/api/auth/%5B...nextauth%5D.ts#L11) and adding the relevant environment variables.
 
 👉 [Setting up Google OAuth](https://support.google.com/cloud/answer/6158849?hl=en)\
 👉 [Setting up Github OAuth](https://docs.github.com/en/free-pro-team@latest/developers/apps/creating-an-oauth-app)
 
-
-
 Update environment variables with your OAuth client ID and secret. e.g. for Github:
+
 ```
 GITHUB_CLIENT_ID=[GITHUB_CLIENT_ID]
 GITHUB_CLIENT_SECRET=[GITHUB_CLIENT_SECRET]
@@ -84,14 +95,31 @@ GITHUB_CLIENT_SECRET=[GITHUB_CLIENT_SECRET]
 <br />
 
 #### Run locally
+
 ```
 yarn dev
 ```
+
 🚀 Go to [localhost:3000](http://localhost:3000/)!
 
 <br />
 
+#### Run local Postgres Database (with Docker Support)
+
+To start a local database service using Postgres docker image, create a container using the attached `docker-compose.yml`
+
+```sh
+docker-compose up -d
+```
+
+To termiate local database service, you can take down running container as such
+
+```sh
+docker-compose down
+```
+
 #### Deploy to Vercel
+
 Applications developed from this boilerplate can be hosted anywhere. These instructions are for deploying via Vercel.
 
 1. [Import](https://vercel.com/import) your project from Github
@@ -109,18 +137,19 @@ Applications developed from this boilerplate can be hosted anywhere. These instr
 **[🐛 Submit a bug](https://github.com/belay-labs/next-fullstack/issues/new?labels=bug&template=bug_report.md)** | **[🐥 Submit a feature request](https://github.com/belay-labs/next-fullstack/issues/new?labels=feature-request&template=feature_request.md)**
 
 #### Review & deployment
- 
+
 Create a PR describing the change you've made and someone will be along to review it and get it merged to master. After changes are merged to `master`, we'll trigger a production deployment to https://next-fullstack-demo.vercel.app/.
 
 <br />
 
 ## Maintainers
+
 Hi! We're [Cathy](https://github.com/cathykc), [Stedman](https://github.com/stedmanblake), and [Zain](https://github.com/tarzain). Feel free email us at cathy@belaylabs.com! 👋
 
 <br />
 
 ## License
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 This project is licensed under the terms of the [Apache-2.0](LICENSE).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: "3"
+services:
+  postgres:
+    image: postgres:13.1
+    healthcheck:
+      test: [ "CMD", "pg_isready", "-q", "-d", "postgres", "-U", "root" ]
+      timeout: 45s
+      interval: 10s
+      retries: 10
+    restart: always
+    environment:
+      - POSTGRES_USER=root
+      - POSTGRES_PASSWORD=password
+      - POSTGRES_DB=postgres
+    volumes:
+      - ./db:/docker-entrypoint-initdb.d/
+    ports:
+      - '5432:5432'

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "db:create": "sequelize-cli db:create",
+    "db:drop": "sequelize-cli db:drop",
+    "db:migrate": "sequelize-cli db:migrate",
+    "db:rollback": "sequelize-cli db:undo",
     "dev": "next dev",
     "build": "next build",
     "start": "next start"


### PR DESCRIPTION
I made a `docker-compose.yml` file that you can set up a local Postgres Database from using Docker and Docker Compose orchestration tools. Added to the readme how to start a local database service and terminate with two commands.

Also added shorthanded ways to run sequelize commands, which reminds me of how I used to run rails db:migrate way back when.